### PR TITLE
Updated alberto

### DIFF
--- a/subdomain.yml
+++ b/subdomain.yml
@@ -39,7 +39,7 @@ CNAME records:
     value: stevemoretz.github.io
     proxy: false
   - name: alberto
-    value: alberto.kajiwara.cf
+    value: 35.212.226.179.nip.io
     proxy: false
 
 # NS records are used to specify the authoritative name servers for the zone.


### PR DESCRIPTION
After adding CNAME I started getting this error from CloudFlare "Error 1014: CNAME Cross-User Banned" 
I've made some changes to the CNAME pointing, and I hope it works correctly now. Previously, I had set up a Cloudflare tunnel to my docker subnet, but it didn't work as expected.
Sorry for any inconvenience caused. I'm still in the process of learning how to properly map external domains.